### PR TITLE
Only consider single solution match

### DIFF
--- a/autoload/cs.vim
+++ b/autoload/cs.vim
@@ -41,6 +41,7 @@ function! cs#get_net_compiler(compiler)
 endfunction
 
 function! cs#find_net_solution_file()
-    return globpath(".", "*.sln")
+    " Just consider first match
+    return get(split(globpath(".", "*.sln"), "\n"), 0, "")
 endfunction
 


### PR DESCRIPTION
I am working with unity and it creates two sln files at the project root resulting in errors from vim-csharp (it says build file is "file1.sln^@file2.sln", which in turn results in an "editor command not found" error.

So this commit just takes the first solution file globpath() finds. Since for my case it doesn't really matter which solution file it takes the guess is "stupid" and just takes the first match.
