### PR TITLE
Add attribute highlighting and don't require attributes to be on their own line

### DIFF
--- a/syntax/cs.vim
+++ b/syntax/cs.vim
@@ -64,7 +64,7 @@ syn keyword csNewDecleration            new nextgroup=csClass skipwhite
 "Interface  & Class Identifier
 syn match csClass contained       /\<[A-Z][a-z]\w\+/ nextgroup=csGeneric
 syn match csIface contained       /\<I[A-Z][a-z]\w\+/ nextgroup=csGeneric
-syn region csGeneric start="<" end=">" contains=csIface,csClass
+" syn region csGeneric start="<" end=">" contains=csIface,csClass
 syn region csEnclosed start="(" end=")" contains=csConstant,csType,csString, csVerbatimString, csCharacter, csNumber,csIface,csClass
 "syn region csInherits start=":" end="{" contains=csIface,csClass
 


### PR DESCRIPTION
Partially fixes #22.

Previously, if an attribute had code after it, it would break the highlighting for the rest of the file.

I also added attributes to the PreProc highlighting group, following the lead of the default vim Java annotation highlighting.
