### PR TITLE
Fix for issue #28

### DIFF
--- a/syntax/cs.vim
+++ b/syntax/cs.vim
@@ -65,7 +65,7 @@ syn keyword csNewDecleration            new nextgroup=csClass skipwhite
 syn match csClass contained       /\<[A-Z][a-z]\w\+/ nextgroup=csGeneric
 syn match csIface contained       /\<I[A-Z][a-z]\w\+/ nextgroup=csGeneric
 " syn region csGeneric start="<" end=">" contains=csIface,csClass
-syn region csEnclosed start="(" end=")" contains=csConstant,csType,csString, csVerbatimString, csCharacter, csNumber,csIface,csClass,csNewDecleration
+syn region csEnclosed start="(" end=")" contains=csConstant,csType,csString, csVerbatimString, csCharacter, csNumber,csIface,csClass,csNewDecleration,csUnspecifiedStatement
 "syn region csInherits start=":" end="{" contains=csIface,csClass
 
 " Attributes

--- a/syntax/cs.vim
+++ b/syntax/cs.vim
@@ -65,7 +65,7 @@ syn keyword csNewDecleration            new nextgroup=csClass skipwhite
 syn match csClass contained       /\<[A-Z][a-z]\w\+/ nextgroup=csGeneric
 syn match csIface contained       /\<I[A-Z][a-z]\w\+/ nextgroup=csGeneric
 " syn region csGeneric start="<" end=">" contains=csIface,csClass
-syn region csEnclosed start="(" end=")" contains=csConstant,csType,csString, csVerbatimString, csCharacter, csNumber,csIface,csClass
+syn region csEnclosed start="(" end=")" contains=csConstant,csType,csString, csVerbatimString, csCharacter, csNumber,csIface,csClass,csNewDecleration
 "syn region csInherits start=":" end="{" contains=csIface,csClass
 
 " Attributes

--- a/syntax/cs.vim
+++ b/syntax/cs.vim
@@ -153,10 +153,6 @@ hi def link csAsync                     Keyword
 hi def link csContextualStatement	Statement
 hi def link csOperatorError		Error
 hi def link csAttribute			PreProc
-
-hi def link csIface                     Type
-hi def link csClass                     Type
-
 hi def link csTodo			Todo
 hi def link csComment			Comment
 


### PR DESCRIPTION
After poking around a bit, I found that I could fix issue #28 by adding `csNewDecleration` to the list of items in the `contains` list for `csEnclosed`. Is this the correct fix? I haven't noticed any unanticipated knock-on effects.
