### PR TITLE
Separate autocmds from plugin/cs.vim

### DIFF
--- a/ftdetect/cs.vim
+++ b/ftdetect/cs.vim
@@ -1,0 +1,15 @@
+" Vim plugin ftdetects
+" Language:     Microsoft C#
+" Maintainer:   Kian Ryan (kian@orangetentacle.co.uk)
+" Last Change:  2015 Apr 27
+
+" Set msproj file extensions
+au BufNewFile,BufRead *.cs compiler msbuild
+au BufNewFile,BufRead *.proj compiler msbuild | set filetype=xml
+au BufNewFile,BufRead *.csproj compiler msbuild | set filetype=xml
+au BufNewFile,BufRead *.sln compiler msbuild | set filetype=xml
+au BufNewFile,BufRead *.cshtml compiler msbuild | set filetype=cshtml.html syntax=cshtml
+au BufNewFile,BufRead *.aspx compiler msbuild | set filetype=aspx.html syntax=aspx
+au BufNewFile,BufRead *.ascx compiler msbuild | set filetype=aspx.html syntax=aspx
+au BufNewFile,BufRead *.master compiler msbuild | set filetype=aspx.html syntax=aspx
+

--- a/plugin/cs.vim
+++ b/plugin/cs.vim
@@ -1,7 +1,7 @@
 " Vim plugin file
 " Language:     Microsoft C#
 " Maintainer:   Kian Ryan (kian@orangetentacle.co.uk)
-" Last Change:  2012 Sep 23
+" Last Change:  2015 Apr 27
 
 function! MsProjFile(file)
     let g:net_build_file = a:file
@@ -16,16 +16,6 @@ endfunction
 function! IISExpress()
     e ~\Documents\IISExpress\config\applicationhost.config
 endfunction
-
-" Set msproj file extensions
-au BufNewFile,BufRead *.cs compiler msbuild
-au BufNewFile,BufRead *.proj compiler msbuild | set filetype=xml
-au BufNewFile,BufRead *.csproj compiler msbuild | set filetype=xml
-au BufNewFile,BufRead *.sln compiler msbuild | set filetype=xml
-au BufNewFile,BufRead *.cshtml compiler msbuild | set filetype=cshtml.html syntax=cshtml
-au BufNewFile,BufRead *.aspx compiler msbuild | set filetype=aspx.html syntax=aspx
-au BufNewFile,BufRead *.ascx compiler msbuild | set filetype=aspx.html syntax=aspx
-au BufNewFile,BufRead *.master compiler msbuild | set filetype=aspx.html syntax=aspx
 
 com! -complete=file -nargs=1 MsProjFile :call MsProjFile(<f-args>)
 com! -nargs=1 MsVersion :call MsVersion(<f-args>)


### PR DESCRIPTION
According to `:help ftdetect`, autocommands which detect file type should be placed in `ftdetect/*.vim`.

This change makes the plugin loaders that supports "lazy-loading" work correctly for filetype detection.
