### PR TITLE
Fix apparent typo, should be v:lnum

### DIFF
--- a/indent/cs.vim
+++ b/indent/cs.vim
@@ -19,7 +19,7 @@ function! GetCSIndent()
   let previous_line = getline(v:lnum - 1)
 
   " Hit the start of the file, use zero indent.
-  if a:lnum == 0
+  if v:lnum == 0
     return 0
   endif
 


### PR DESCRIPTION
This is causing an error for me to occur whenever `GetCSIndent()` gets called. `a:lnum` appears to be a typo, as this function does not take an `lnum` argument.

`v:lnum` is the correct way to access the `lnum` global Vim variable.

After making this change locally, I am no longer getting the error.