### PR TITLE
Minor syntax improvements pulled from Omnisharp's old syntax file

### DIFF
--- a/syntax/cs.vim
+++ b/syntax/cs.vim
@@ -30,7 +30,7 @@ syn match csGlobal          display +global::+
 " user labels (see [1] 8.6 Statements)
 syn match   csLabel			display +^\s*\I\i*\s*:\([^:]\)\@=+
 " modifier
-syn keyword csModifier			abstract const extern internal override private protected public readonly sealed static virtual volatile nextgroup=CsClass,CsIface skipwhite
+syn keyword csModifier			abstract const extern internal override private protected public readonly sealed static virtual volatile nextgroup=csClass,csIface skipwhite
 " constant
 syn keyword csConstant			false null true
 " exception

--- a/syntax/cs.vim
+++ b/syntax/cs.vim
@@ -26,7 +26,7 @@ syn keyword csConditional		else if switch
 syn keyword csLabel			case default
 " :: is usually an error in C#, except for the special case of "global::"
 syn match csOperatorError		display +::+
-syn match csGlobal          display +global::+
+syn match csGlobal                      display +global::+
 " user labels (see [1] 8.6 Statements)
 syn match   csLabel			display +^\s*\I\i*\s*:\([^:]\)\@=+
 " modifier
@@ -56,7 +56,7 @@ syn match csContextualStatement	/\<yield[[:space:]\n]\+\(return\|break\)/me=s+5
 syn match csContextualStatement	/\<partial[[:space:]\n]\+\(class\|struct\|interface\)/me=s+7
 syn match csContextualStatement	/\<\(get\|set\);/me=s+3
 syn match csContextualStatement	/\<\(get\|set\)[[:space:]\n]*{/me=s+3
-syn match csContextualStatement /\<where\>[^:]\+:/me=s+5
+syn match csContextualStatement	/\<where\>[^:]\+:/me=s+5
 
 "New Declerations
 syn keyword csNewDecleration            new nextgroup=csClass skipwhite

--- a/syntax/cs.vim
+++ b/syntax/cs.vim
@@ -46,7 +46,7 @@ syn keyword csUnspecifiedKeyword	explicit implicit
 syn keyword csTypeOf                    typeof nextgroup=csEnclosed
 
 " Linq Keywords
-syn keyword csLinq                      from where select group into orderby join let in on equals by ascending descending
+syn keyword csLinq                      ascending by descending equals from group in into join let on orderby select where
 
 " Async Keywords
 syn keyword csAsync                     async await


### PR DESCRIPTION
I spent some time trying to figure out if there are improvements to be pulled from [OmniSharp's cs.vim](https://raw.githubusercontent.com/OmniSharp/omnisharp-vim/5a68fdd87755d70343a756cd23de9dde84313808/syntax/cs.vim) (it was removed and so I found your project.

There are tons of differences. The ones I could extract are pretty minor. In the meantime, [vim-cs](https://github.com/nickspoons/vim-cs) was created as a new home for OmniSharp's cs.vim and has tried to figure out which of your changes are superior.