### PR TITLE
Improve handling of compiler directives and attributes

### DIFF
--- a/indent/cs.vim
+++ b/indent/cs.vim
@@ -20,21 +20,36 @@ function! s:IsAttributeLine(line)
   return a:line =~? '^\s*\[[A-Za-z]' && a:line =~? '\]$'
 endf
 
+function! s:FindPreviousNonCompilerDirectiveLine(start_lnum)
+  for delta in range(0, a:start_lnum)
+    let lnum = a:start_lnum - delta
+    let line = getline(lnum)
+    let is_directive = s:IsCompilerDirective(line)
+    if !is_directive
+      return lnum
+    endif
+  endfor
+  return 0
+endf
+
 function! GetCSIndent(lnum) abort
-
-  let this_line = getline(a:lnum)
-  let previous_line = getline(a:lnum - 1)
-
   " Hit the start of the file, use zero indent.
   if a:lnum == 0
     return 0
   endif
 
+  let this_line = getline(a:lnum)
+
   " Compiler directives use zero indent if so configured.
   let is_first_col_macro = s:IsCompilerDirective(this_line) && stridx(&l:cinkeys, '0#') >= 0
+  if is_first_col_macro
+    return cindent(a:lnum)
+  endif
 
-  if !is_first_col_macro && s:IsAttributeLine(previous_code_line)
-    let ind = indent(a:lnum - 1)
+  let lnum = s:FindPreviousNonCompilerDirectiveLine(a:lnum - 1)
+  let previous_code_line = getline(lnum)
+  if s:IsAttributeLine(previous_code_line)
+    let ind = indent(lnum)
     return ind
   else
     return cindent(a:lnum)

--- a/indent/cs.vim
+++ b/indent/cs.vim
@@ -23,8 +23,11 @@ function! GetCSIndent(lnum) abort
     return 0
   endif
 
+  " Compiler directives use zero indent if so configured.
+  let is_first_col_macro = this_line =~? '^\s*#' && stridx(&l:cinkeys, '0#') >= 0
+
   " If previous_line is an attribute line:
-  if previous_line =~? '^\s*\[[A-Za-z]' && previous_line =~? '\]$'
+  if !is_first_col_macro && previous_line =~? '^\s*\[[A-Za-z]' && previous_line =~? '\]$'
     let ind = indent(a:lnum - 1)
     return ind
   else

--- a/indent/cs.vim
+++ b/indent/cs.vim
@@ -12,6 +12,13 @@ let b:did_indent = 1
 
 setlocal indentexpr=GetCSIndent(v:lnum)
 
+function! s:IsCompilerDirective(line)
+  return a:line =~? '^\s*#'
+endf
+
+function! s:IsAttributeLine(line)
+  return a:line =~? '^\s*\[[A-Za-z]' && a:line =~? '\]$'
+endf
 
 function! GetCSIndent(lnum) abort
 
@@ -24,10 +31,9 @@ function! GetCSIndent(lnum) abort
   endif
 
   " Compiler directives use zero indent if so configured.
-  let is_first_col_macro = this_line =~? '^\s*#' && stridx(&l:cinkeys, '0#') >= 0
+  let is_first_col_macro = s:IsCompilerDirective(this_line) && stridx(&l:cinkeys, '0#') >= 0
 
-  " If previous_line is an attribute line:
-  if !is_first_col_macro && previous_line =~? '^\s*\[[A-Za-z]' && previous_line =~? '\]$'
+  if !is_first_col_macro && s:IsAttributeLine(previous_code_line)
     let ind = indent(a:lnum - 1)
     return ind
   else

--- a/indent/cs.vim
+++ b/indent/cs.vim
@@ -4,31 +4,33 @@
 "
 
 " Only load this indent file when no other was loaded.
-if exists("b:did_indent")
+if exists('b:did_indent')
    finish
 endif
 let b:did_indent = 1
 
 
-setlocal indentexpr=GetCSIndent()
+setlocal indentexpr=GetCSIndent(v:lnum)
 
 
-function! GetCSIndent()
+function! GetCSIndent(lnum) abort
 
-  let this_line = getline(v:lnum)
-  let previous_line = getline(v:lnum - 1)
+  let this_line = getline(a:lnum)
+  let previous_line = getline(a:lnum - 1)
 
   " Hit the start of the file, use zero indent.
-  if v:lnum == 0
+  if a:lnum == 0
     return 0
   endif
 
   " If previous_line is an attribute line:
   if previous_line =~? '^\s*\[[A-Za-z]' && previous_line =~? '\]$'
-    let ind = indent(v:lnum - 1)
+    let ind = indent(a:lnum - 1)
     return ind
   else
-    return cindent(v:lnum)
+    return cindent(a:lnum)
   endif
 
 endfunction
+
+" vim:et:sw=2:sts=2


### PR DESCRIPTION
Support zero-column compiler directives.

Handle attributes followed by compiler directives.

I've also made a PR for these changes to [nickspoons/vim-cs](https://github.com/nickspoons/vim-cs). I'll push future fixes there, since the maintainer is more active.