### PR TITLE
Add Razor syntax highlighting

### DIFF
--- a/ftdetect/cs.vim
+++ b/ftdetect/cs.vim
@@ -9,6 +9,7 @@ au BufNewFile,BufRead *.proj compiler msbuild | set filetype=xml
 au BufNewFile,BufRead *.csproj compiler msbuild | set filetype=xml
 au BufNewFile,BufRead *.sln compiler msbuild | set filetype=xml
 au BufNewFile,BufRead *.cshtml compiler msbuild | set filetype=cshtml.html syntax=cshtml
+au BufNewFile,BufRead *.razor compiler msbuild | set filetype=cshtml.html syntax=cshtml
 au BufNewFile,BufRead *.aspx compiler msbuild | set filetype=aspx.html syntax=aspx
 au BufNewFile,BufRead *.ascx compiler msbuild | set filetype=aspx.html syntax=aspx
 au BufNewFile,BufRead *.master compiler msbuild | set filetype=aspx.html syntax=aspx


### PR DESCRIPTION
Found that the plugin didn't pick up on `.razor` files.