### PR TITLE
ensure solution filenames are quoted

### DIFF
--- a/compiler/msbuild.vim
+++ b/compiler/msbuild.vim
@@ -30,7 +30,7 @@ endif
 
 execute 'CompilerSet makeprg=' . cs#get_net_compiler("msbuild") . "\\ " 
             \ . "/nologo\\ /clp:Verbosity=quiet\\ /property:GenerateFullPaths=true\\ "
-            \ . s:build_file
+            \ . "\"" . s:build_file . "\""
 
 
 


### PR DESCRIPTION
to handle spaces in solution filenames

we have a lot of solution files with spaces in the name, and I always get this error when running `:Ack`:

![image](https://user-images.githubusercontent.com/744206/84821997-dcc24900-afd0-11ea-9619-843f2b18e3fe.png)

The solution filename in this case was `Addins Plus.sln`

If there are any other locations in the repo where this should be done, let me know I am happy to fix them.